### PR TITLE
feat: add target for a bare version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,8 @@ var commonsFiles = [
 var files = {
   standalone: [underscoreLite, jqLite].concat(commonsFiles),
   jquery: [underscoreLite].concat(commonsFiles),
-  underscore: [jqLite].concat(commonsFiles)
+  underscore: [jqLite].concat(commonsFiles),
+  bare: commonsFiles
 };
 
 var testFiles = files.standalone.concat([

--- a/templates/wrap-template-bare.js
+++ b/templates/wrap-template-bare.js
@@ -1,0 +1,47 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Mickael Jeanroy, Cedric Nisio
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+(function(window, document, undefined) {
+
+  (function (factory) {
+
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery', 'underscore'], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS
+        module.exports = factory(require('jquery'), require('underscore'));
+    } else {
+        // Browser globals
+        factory(jQuery, _);
+    }
+
+  }(function ($, _) {
+
+'use strict';
+<%= contents %>
+
+  }));
+
+})(window, document, void 0);


### PR DESCRIPTION
add target to release a bare version with
jQuery and underscore as mandatory dependencies.