### PR TITLE
fix(jq-lite): remove space preceding css class

### DIFF
--- a/src/jq-lite.js
+++ b/src/jq-lite.js
@@ -124,7 +124,8 @@ $.prototype = {
   addClass: function(classes) {
     var css = _.isArray(classes) ? classes.join(' ') : classes;
     return this.$$each(function(node) {
-      node.className = node.className + ' ' + css;
+      var actualCss = node.className;
+      node.className = (actualCss ? actualCss + ' ' : '') + css;
     });
   },
 

--- a/test/grid-spec.js
+++ b/test/grid-spec.js
@@ -197,7 +197,7 @@ describe('Grid', function() {
         'waffle-sortable'
       ];
 
-      return node.className === ' ' + cssClasses.join(' ');
+      return node.className === cssClasses.join(' ');
     });
 
     expect(ths).toVerify(function(node, idx) {
@@ -250,8 +250,8 @@ describe('Grid', function() {
       var css1 = [columns[0].id, 'waffle-sortable'];
       var css2 = [columns[1].id, 'waffle-sortable'];
       var tds = node.childNodes;
-      return tds[0].className === ' '+ css1.join(' ') &&
-             tds[1].className === ' ' + css2.join(' ');
+      return tds[0].className === css1.join(' ') &&
+             tds[1].className === css2.join(' ');
     });
 
     expect(trs).toVerify(function(node, idx) {

--- a/test/jq-lite-spec.js
+++ b/test/jq-lite-spec.js
@@ -100,13 +100,13 @@ describe('$', function() {
     it('should add class to node', function() {
       var $result = $div.addClass('foo');
       expect($result).toBe($div);
-      expect($div[0].className).toBe(' foo');
+      expect($div[0].className).toBe('foo');
     });
 
     it('should add array of classes to node', function() {
       var $result = $div.addClass(['foo', 'bar']);
       expect($result).toBe($div);
-      expect($div[0].className).toBe(' foo bar');
+      expect($div[0].className).toBe('foo bar');
     });
 
     it('should bind and unbind event', function() {


### PR DESCRIPTION
remove the space preceding css classes added with
jq-lite addClass when no previous class was set