### PR TITLE
fix(build): fixed gulp server watch tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -168,15 +168,8 @@ gulp.task('server', ['concat'], function () {
     file:'sample-server.js'
   });
 
-  gulp.watch(['src/**/*.js'], function(event) {
-    gulp.run('concat');
-    server.notify(event);
-  });
-
-  gulp.watch(['src/less/*.less'], function(event) {
-    gulp.run('less');
-    server.notify(event);
-  });
-
+  gulp.watch(['src/**/*.js'], ['concat']);
+  gulp.watch(['src/less/*.less'], ['less']);
+  gulp.watch(['dist/**/*'], server.notify);
   gulp.watch(['sample/**/*'], server.notify);
 });


### PR DESCRIPTION
watch on source files was notifying server before concat/less task
finished their job which ended in a broken livereload

watch on source files now only triggers concat or less task
add watch on dist folder to trigger livereload